### PR TITLE
Remove keyword in cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = ["wcampbell"]
 edition = "2018"
 description = "a rust library for interacting with saleae devices"
-keywords = ["logic", "saleae", "api", "re", "reverse", "engineering"]
+keywords = ["logic", "saleae", "api", "re", "reverse"]
 maintenance = { status = "actively-developed" }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
```
This is a list of up to five keywords that describe this crate. Keywords
are searchable on crates.io, and you may choose any words that would
help someone find this crate.
```