### PR TITLE
Feature/mocking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,7 @@ bufstream = "0.1.1"
 anyhow = "1.0.26"
 enum_derive = "0.1.7"
 custom_derive = "0.1.7"
+faux = "0.0.3"
+
+[dev-dependencies]
+#faux = "0.0.3"

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -2,7 +2,6 @@ use saleae;
 
 use saleae::PerformanceOption;
 use saleae::{Client, Connection};
-use std::net::TcpStream;
 use std::thread;
 use std::time::Duration;
 

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -30,7 +30,7 @@ fn main() {
     let response6 = conn.start_capture_block_until_finished();
     println!("longer waiting is complete: {:?}", response6.unwrap());
 
-    let response = conn.set_capture_seconds(10);
+    let response = conn.set_capture_seconds(10.1);
     println!("set_capture_seconds: {:?}", response.unwrap());
 
     let response4 = conn.start_capture();

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,13 +1,13 @@
 use saleae;
 
-use saleae::Client;
 use saleae::PerformanceOption;
+use saleae::{Client, Connection};
 use std::net::TcpStream;
 use std::thread;
 use std::time::Duration;
 
 fn main() {
-    let mut conn = Client::new(TcpStream::connect("127.0.0.1:10429").unwrap()).unwrap();
+    let mut conn = Client::new(Connection::new("127.0.0.1:10429")).unwrap();
     let response0 = conn.get_performance();
     println!("get_performance: {}", response0.unwrap());
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -94,11 +94,9 @@ impl Client {
     }
 
     /// Set the capture duration to a length of time
-    pub fn set_capture_seconds(&mut self, seconds: u8) -> Result<bool> {
-        //TODO check input
-        //TODO support floating point
+    pub fn set_capture_seconds(&mut self, seconds: f32) -> Result<bool> {
         self.connection
-            .run_command(&format!("set_capture_seconds, {}.0\0", seconds))?;
+            .run_command(&format!("set_capture_seconds, {}\0", seconds))?;
         Ok(self.connection.general_recieve_ack()?)
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,221 +12,26 @@ use crate::request::Request;
 use crate::response::Response;
 use crate::samplerate::SampleRate;
 
+#[faux::create]
 #[derive(Debug)]
-/// Main interface for communication to Saleae Logic
-pub struct Client {
-    /// tcp stream with connection to saleae
+pub struct Connection {
     stream: TcpStream,
 }
 
-/// Constructor
-impl Client {
-    /// constructor
-    pub fn new(stream: TcpStream) -> Result<Client> {
-        Ok(Client { stream })
-    }
-}
-
-/// Interface for setting and getting Logic information
-impl Client {
-    /// Set a trigger of channels
-    /// TODO create trigger methods/structs/tests
-
-    pub fn set_num_samples(&mut self, num: u32) -> Result<bool> {
-        self.run_command(&format!("set_num_samples, {}\0", num))?;
-        Ok(self.general_recieve_ack()?)
+#[faux::methods]
+impl Connection {
+    pub fn new(ip_port: &str) -> Self {
+        Connection {
+            stream: TcpStream::connect(ip_port).unwrap(),
+        }
     }
 
-    pub fn get_num_samples(&mut self) -> Result<u32> {
-        self.run_command("get_num_samples\0")?;
-        let response = self.general_recieve_message()?;
-        Ok(Response::parse_num_samples(&Response::remove_ack(
-            &response,
-        )))
-    }
-
-    /// Set the capture duration to a length of time
-    pub fn set_capture_seconds(&mut self, seconds: u8) -> Result<bool> {
-        //TODO check input
-        //TODO support floating point
-        self.run_command(&format!("set_capture_seconds, {}.0\0", seconds))?;
-        Ok(self.general_recieve_ack()?)
-    }
-
-    /// Set sample rate of saleae
-    ///
-    /// Note: Make sure to run `get_all_sample_rates` and set it from a available
-    /// sample rate
-    pub fn set_sample_rate(&mut self, rate: &SampleRate) -> Result<bool> {
-        self.run_command(&format!(
-            "set_sample_rate, {}, {}\0",
-            rate.AnalogSampleRate, rate.DigitalSampleRate
-        ))?;
-        Ok(self.general_recieve_ack()?)
-    }
-
-    pub fn get_sample_rate(&mut self) -> Result<SampleRate> {
-        self.run_command("get_sample_rate\0")?;
-        let response = self.general_recieve_message()?;
-        Ok(Response::parse_get_sample_rate(&Response::remove_ack(
-            &response,
-        )))
-    }
-
-    pub fn get_all_sample_rates(&mut self) -> Result<Vec<SampleRate>> {
-        self.run_command("get_all_sample_rates\0")?;
-        let response = self.general_recieve_message()?;
-        Ok(Response::parse_get_all_sample_rates(&Response::remove_ack(
-            &response,
-        )))
-    }
-
-    /// Return current performance level of Logic
-    pub fn get_performance(&mut self) -> Result<u8> {
-        self.run_command("get_performance\0")?;
-        let response = self.general_recieve_message()?;
-        Ok(Response::parse_performance(&Response::remove_ack(
-            &response,
-        )))
-    }
-
-    /// Set the performance value, controlling the USB traffic and quality
-    pub fn set_performance(&mut self, perf: PerformanceOption) -> Result<bool> {
-        let input = String::from(&format!("set_performance, {}\0", perf as i32));
-        self.run_command(&input)?;
-        Ok(self.general_recieve_ack()?)
-    }
-
-    //TODO get_capture_pretrigger_buffer_size
-
-    /// Return current connected devices of Logic
-    pub fn get_connected_devices(&mut self) -> Result<Vec<ConnectedDevice>> {
-        self.run_command("get_connected_devices\0")?;
-        let response = self.general_recieve_message()?;
-        Ok(Response::parse_connected_devices(&Response::remove_ack(
-            &response,
-        )))
-    }
-
-    /// Find index of device from the list of devices connected to Saleae
-    ///
-    /// Note: Indices start at 1, not 0
-    /// TODO: test with multiple saleae
-    pub fn select_active_device(&mut self, device: ConnectedDevice) -> Result<bool> {
-        let b = self
-            .get_connected_devices()
-            .unwrap()
-            .into_iter()
-            .position(|a| a == device);
-        self.run_command(&format!("select_active_device, {}", b.unwrap() + 1))?;
-        //TODO check ack?
-        Ok(true)
-    }
-
-    /// Return current active device of Logic
-    pub fn get_active_device(&mut self) -> Result<ConnectedDevice> {
-        self.run_command("get_connected_devices\0")?;
-        //TODO lol clean this up
-        let response = self.general_recieve_message()?;
-        Ok(
-            Response::parse_connected_devices(&Response::remove_ack(&response))
-                .into_iter()
-                .find(|a| a.is_active)
-                .unwrap(),
-        )
-    }
-
-    /// Parse the get active channels command into tuples of digital and analog
-    /// channels that are current
-    pub fn get_active_channels(&mut self) -> Result<(Vec<Vec<u8>>)> {
-        self.run_command("get_active_channels\0")?;
-        let response = self.general_recieve_message()?;
-        Ok(Response::parse_get_active_channels(&Response::remove_ack(
-            &response,
-        ))?)
-    }
-
-    /// Set the active channels for the Logic program
-    ///
-    /// # Example
-    /// TODO add get_active_channels
-    pub fn set_active_channels(
-        &mut self,
-        digital_channels: &[u8],
-        analog_channels: &[u8],
-    ) -> Result<bool> {
-        self.run_command(&Request::prepare_set_active_channels(
-            &digital_channels,
-            &analog_channels,
-        )?)?;
-        Ok(self.general_recieve_ack()?)
-    }
-
-    /// Reset Active Channel
-    pub fn reset_active_channels(&mut self) -> Result<bool> {
-        self.run_command("reset_active_channels\0")?;
-        Ok(self.general_recieve_ack()?)
-    }
-
-    //TODO get_digital_voltage_options OR get_full_scale_voltage_range
-    //TODO set_full_scale_voltage_range
-
-    /// Start Capture, without wating for ack/nack
-    pub fn start_capture(&mut self) -> Result<bool> {
-        self.run_command("capture\0")?;
-        //TODO check ack?
-        Ok(true)
-    }
-
-    /// Start Capture, then wait until ack
-    pub fn start_capture_block_until_finished(&mut self) -> Result<bool> {
-        self.start_capture()?;
-        Ok(self.general_recieve_ack()?)
-    }
-
-    /// Check if processing is complete
-    pub fn is_processing_complete(&mut self) -> Result<bool> {
-        self.run_command("is_processing_complete\0")?;
-        let response = self.general_recieve_message()?;
-        Ok(Response::parse_processing_complete(&Response::remove_ack(
-            &response,
-        )))
-    }
-
-    /// Stop the saleae capture
-    pub fn stop_capture(&mut self) -> Result<bool> {
-        self.run_command("stop_capture\0")?;
-        Ok(self.general_recieve_ack()?)
-    }
-
-    //TODO capture_to_file
-    //TODO save_to_file
-    //TODO load_from_file
-
-    /// Close all tabs
-    pub fn close_all_tabs(&mut self) -> Result<bool> {
-        self.run_command("close_all_tabs\0")?;
-        Ok(self.general_recieve_ack()?)
-    }
-
-    //TODO export_data2
-    //TODO get_analyzers
-    //TODO export_analyzer
-    //TODO is_analyzer_complete
-    //TODO get_capture_range
-    //TODO get_viewstate
-    //TODO get_viewstate
-    //TODO exit
-}
-
-/// private functions for socket functions
-impl Client {
     fn general_recieve_ack(&mut self) -> Result<bool> {
         let r: String = std::str::from_utf8(&self.read_line()?)?.to_string();
         Ok(Response::verify_ack(&r))
     }
 
-    fn general_recieve_message(&mut self) -> Result<String> {
+    pub fn general_recieve_message(&mut self) -> Result<String> {
         let msg: String = std::str::from_utf8(&self.read_line()?)?.to_string();
         Response::verify_ack(&msg);
         Ok(msg)
@@ -243,7 +48,7 @@ impl Client {
     }
 
     //TODO Support for parameters
-    fn run_command(&mut self, command: &str) -> Result<()> {
+    pub fn run_command(&mut self, command: &str) -> Result<()> {
         let mut writer = BufWriter::new(&self.stream);
         let len = writer.write(command.as_bytes()).unwrap();
         if len < 1 {
@@ -251,4 +56,216 @@ impl Client {
         }
         Ok(())
     }
+}
+
+#[derive(Debug)]
+/// Main interface for communication to Saleae Logic
+pub struct Client {
+    /// tcp stream with connection to saleae
+    connection: Connection,
+}
+
+/// Constructor
+impl Client {
+    /// constructor
+    //TODO make this create a connection from a string
+    pub fn new(connection: Connection) -> Result<Client> {
+        Ok(Client { connection })
+    }
+}
+
+/// Interface for setting and getting Logic information
+impl Client {
+    /// Set a trigger of channels
+    /// TODO create trigger methods/structs/tests
+
+    pub fn set_num_samples(&mut self, num: u32) -> Result<bool> {
+        self.connection
+            .run_command(&format!("set_num_samples, {}\0", num))?;
+        Ok(self.connection.general_recieve_ack()?)
+    }
+
+    pub fn get_num_samples(&mut self) -> Result<u32> {
+        self.connection.run_command("get_num_samples\0")?;
+        let response = self.connection.general_recieve_message()?;
+        Ok(Response::parse_num_samples(&Response::remove_ack(
+            &response,
+        )))
+    }
+
+    /// Set the capture duration to a length of time
+    pub fn set_capture_seconds(&mut self, seconds: u8) -> Result<bool> {
+        //TODO check input
+        //TODO support floating point
+        self.connection
+            .run_command(&format!("set_capture_seconds, {}.0\0", seconds))?;
+        Ok(self.connection.general_recieve_ack()?)
+    }
+
+    /// Set sample rate of saleae
+    ///
+    /// Note: Make sure to run `get_all_sample_rates` and set it from a available
+    /// sample rate
+    pub fn set_sample_rate(&mut self, rate: &SampleRate) -> Result<bool> {
+        self.connection.run_command(&format!(
+            "set_sample_rate, {}, {}\0",
+            rate.AnalogSampleRate, rate.DigitalSampleRate
+        ))?;
+        Ok(self.connection.general_recieve_ack()?)
+    }
+
+    pub fn get_sample_rate(&mut self) -> Result<SampleRate> {
+        self.connection.run_command("get_sample_rate\0")?;
+        let response = self.connection.general_recieve_message()?;
+        Ok(Response::parse_get_sample_rate(&Response::remove_ack(
+            &response,
+        )))
+    }
+
+    pub fn get_all_sample_rates(&mut self) -> Result<Vec<SampleRate>> {
+        self.connection.run_command("get_all_sample_rates\0")?;
+        let response = self.connection.general_recieve_message()?;
+        Ok(Response::parse_get_all_sample_rates(&Response::remove_ack(
+            &response,
+        )))
+    }
+
+    /// Return current performance level of Logic
+    pub fn get_performance(&mut self) -> Result<u8> {
+        self.connection.run_command("get_performance\0")?;
+        let response = self.connection.general_recieve_message()?;
+        Ok(Response::parse_performance(&Response::remove_ack(
+            &response,
+        )))
+    }
+
+    /// Set the performance value, controlling the USB traffic and quality
+    pub fn set_performance(&mut self, perf: PerformanceOption) -> Result<bool> {
+        let input = String::from(&format!("set_performance, {}\0", perf as i32));
+        self.connection.run_command(&input)?;
+        Ok(self.connection.general_recieve_ack()?)
+    }
+
+    //TODO get_capture_pretrigger_buffer_size
+
+    /// Return current connected devices of Logic
+    pub fn get_connected_devices(&mut self) -> Result<Vec<ConnectedDevice>> {
+        self.connection.run_command("get_connected_devices\0")?;
+        let response = self.connection.general_recieve_message()?;
+        Ok(Response::parse_connected_devices(&Response::remove_ack(
+            &response,
+        )))
+    }
+
+    /// Find index of device from the list of devices connected to Saleae
+    ///
+    /// Note: Indices start at 1, not 0
+    /// TODO: test with multiple saleae
+    pub fn select_active_device(&mut self, device: ConnectedDevice) -> Result<bool> {
+        let b = self
+            .get_connected_devices()
+            .unwrap()
+            .into_iter()
+            .position(|a| a == device);
+        self.connection
+            .run_command(&format!("select_active_device, {}", b.unwrap() + 1))?;
+        //TODO check ack?
+        Ok(true)
+    }
+
+    /// Return current active device of Logic
+    pub fn get_active_device(&mut self) -> Result<ConnectedDevice> {
+        self.connection.run_command("get_connected_devices\0")?;
+        //TODO lol clean this up
+        let response = self.connection.general_recieve_message()?;
+        Ok(
+            Response::parse_connected_devices(&Response::remove_ack(&response))
+                .into_iter()
+                .find(|a| a.is_active)
+                .unwrap(),
+        )
+    }
+
+    /// Parse the get active channels command into tuples of digital and analog
+    /// channels that are current
+    pub fn get_active_channels(&mut self) -> Result<(Vec<Vec<u8>>)> {
+        self.connection.run_command("get_active_channels\0")?;
+        let response = self.connection.general_recieve_message()?;
+        Ok(Response::parse_get_active_channels(&Response::remove_ack(
+            &response,
+        ))?)
+    }
+
+    /// Set the active channels for the Logic program
+    ///
+    /// # Example
+    /// TODO add get_active_channels
+    pub fn set_active_channels(
+        &mut self,
+        digital_channels: &[u8],
+        analog_channels: &[u8],
+    ) -> Result<bool> {
+        self.connection
+            .run_command(&Request::prepare_set_active_channels(
+                &digital_channels,
+                &analog_channels,
+            )?)?;
+        Ok(self.connection.general_recieve_ack()?)
+    }
+
+    /// Reset Active Channel
+    pub fn reset_active_channels(&mut self) -> Result<bool> {
+        self.connection.run_command("reset_active_channels\0")?;
+        Ok(self.connection.general_recieve_ack()?)
+    }
+
+    //TODO get_digital_voltage_options OR get_full_scale_voltage_range
+    //TODO set_full_scale_voltage_range
+
+    /// Start Capture, without wating for ack/nack
+    pub fn start_capture(&mut self) -> Result<bool> {
+        self.connection.run_command("capture\0")?;
+        //TODO check ack?
+        Ok(true)
+    }
+
+    /// Start Capture, then wait until ack
+    pub fn start_capture_block_until_finished(&mut self) -> Result<bool> {
+        self.start_capture()?;
+        Ok(self.connection.general_recieve_ack()?)
+    }
+
+    /// Check if processing is complete
+    pub fn is_processing_complete(&mut self) -> Result<bool> {
+        self.connection.run_command("is_processing_complete\0")?;
+        let response = self.connection.general_recieve_message()?;
+        Ok(Response::parse_processing_complete(&Response::remove_ack(
+            &response,
+        )))
+    }
+
+    /// Stop the saleae capture
+    pub fn stop_capture(&mut self) -> Result<bool> {
+        self.connection.run_command("stop_capture\0")?;
+        Ok(self.connection.general_recieve_ack()?)
+    }
+
+    //TODO capture_to_file
+    //TODO save_to_file
+    //TODO load_from_file
+
+    /// Close all tabs
+    pub fn close_all_tabs(&mut self) -> Result<bool> {
+        self.connection.run_command("close_all_tabs\0")?;
+        Ok(self.connection.general_recieve_ack()?)
+    }
+
+    //TODO export_data2
+    //TODO get_analyzers
+    //TODO export_analyzer
+    //TODO is_analyzer_complete
+    //TODO get_capture_range
+    //TODO get_viewstate
+    //TODO get_viewstate
+    //TODO exit
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -107,7 +107,7 @@ impl Client {
     pub fn set_sample_rate(&mut self, rate: &SampleRate) -> Result<bool> {
         self.connection.run_command(&format!(
             "set_sample_rate, {}, {}\0",
-            rate.AnalogSampleRate, rate.DigitalSampleRate
+            rate.DigitalSampleRate, rate.AnalogSampleRate
         ))?;
         Ok(self.connection.general_recieve_ack()?)
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -88,11 +88,12 @@ impl Client {
     pub fn get_num_samples(&mut self) -> Result<u32> {
         self.connection.run_command("get_num_samples\0")?;
         let response = self.connection.general_recieve_message()?;
-        match Response::verify_ack(&response) {
-            true => Ok(Response::parse_num_samples(&Response::remove_ack(
+        if Response::verify_ack(&response) {
+            Ok(Response::parse_num_samples(&Response::remove_ack(
                 &response,
-            ))),
-            false => return Err(anyhow!("No ACK found")),
+            )))
+        } else {
+            Err(anyhow!("No ACK found"))
         }
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -161,6 +161,9 @@ impl Client {
 
     /// Find index of device from the list of devices connected to Saleae
     ///
+    /// Get current index of connected devices and find equal device to parameter.
+    /// Send that device as active device to logic.
+    ///
     /// Note: Indices start at 1, not 0
     /// TODO: test with multiple saleae
     pub fn select_active_device(&mut self, device: ConnectedDevice) -> Result<bool> {
@@ -171,14 +174,13 @@ impl Client {
             .position(|a| a == device);
         self.connection
             .run_command(&format!("select_active_device, {}", b.unwrap() + 1))?;
-        //TODO check ack?
+        // Weirdly doesn't return an ACK
         Ok(true)
     }
 
     /// Return current active device of Logic
     pub fn get_active_device(&mut self) -> Result<ConnectedDevice> {
         self.connection.run_command("get_connected_devices\0")?;
-        //TODO lol clean this up
         let response = self.connection.general_recieve_message()?;
         Ok(
             Response::parse_connected_devices(&Response::remove_ack(&response))
@@ -190,7 +192,7 @@ impl Client {
 
     /// Parse the get active channels command into tuples of digital and analog
     /// channels that are current
-    pub fn get_active_channels(&mut self) -> Result<(Vec<Vec<u8>>)> {
+    pub fn get_active_channels(&mut self) -> Result<Vec<Vec<u8>>> {
         self.connection.run_command("get_active_channels\0")?;
         let response = self.connection.general_recieve_message()?;
         Ok(Response::parse_get_active_channels(&Response::remove_ack(
@@ -227,8 +229,8 @@ impl Client {
     /// Start Capture, without wating for ack/nack
     pub fn start_capture(&mut self) -> Result<bool> {
         self.connection.run_command("capture\0")?;
-        //TODO check ack?
         Ok(true)
+        // Doesn't return ACK
     }
 
     /// Start Capture, then wait until ack

--- a/src/client.rs
+++ b/src/client.rs
@@ -89,12 +89,10 @@ impl Client {
         self.connection.run_command("get_num_samples\0")?;
         let response = self.connection.general_recieve_message()?;
         match Response::verify_ack(&response) {
-            true => {
-                Ok(Response::parse_num_samples(&Response::remove_ack(
-                    &response,
-                )))
-            }
-            false => return Err(anyhow!("No ACK found"))
+            true => Ok(Response::parse_num_samples(&Response::remove_ack(
+                &response,
+            ))),
+            false => return Err(anyhow!("No ACK found")),
         }
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -26,7 +26,7 @@ impl Connection {
         }
     }
 
-    fn general_recieve_ack(&mut self) -> Result<bool> {
+    pub fn general_recieve_ack(&mut self) -> Result<bool> {
         let r: String = std::str::from_utf8(&self.read_line()?)?.to_string();
         Ok(Response::verify_ack(&r))
     }
@@ -88,9 +88,14 @@ impl Client {
     pub fn get_num_samples(&mut self) -> Result<u32> {
         self.connection.run_command("get_num_samples\0")?;
         let response = self.connection.general_recieve_message()?;
-        Ok(Response::parse_num_samples(&Response::remove_ack(
-            &response,
-        )))
+        match Response::verify_ack(&response) {
+            true => {
+                Ok(Response::parse_num_samples(&Response::remove_ack(
+                    &response,
+                )))
+            }
+            false => return Err(anyhow!("No ACK found"))
+        }
     }
 
     /// Set the capture duration to a length of time

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,10 @@
 //! ```rust, no_run
 //! extern crate saleae;
 //!
-//! use saleae::Client;
+//! use saleae::{Client, Connection};
 //! use std::net::TcpStream;
 //!
-//! let mut conn = Client::new(TcpStream::connect("127.0.0.1:10429").unwrap()).unwrap();
+//! let mut conn = Client::new(Connection::new("127.0.0.1:10429")).unwrap();
 //! let response0 = conn.get_performance();
 //! println!("get_performance: {}", response0.unwrap());
 //!
@@ -34,6 +34,7 @@ extern crate bufstream;
 extern crate custom_derive;
 #[macro_use]
 extern crate enum_derive;
+extern crate faux;
 
 pub mod client;
 pub mod device;
@@ -42,7 +43,7 @@ pub mod request;
 pub mod response;
 pub mod samplerate;
 
-pub use client::Client;
+pub use client::{Client, Connection};
 pub use device::ConnectedDevice;
 pub use performance::PerformanceOption;
 pub use samplerate::SampleRate;

--- a/src/request.rs
+++ b/src/request.rs
@@ -2,7 +2,7 @@
 //!
 //! The function here parse and type check the input from the API into strings to send into
 //! the Saleae socket
-use anyhow::{Error, Result};
+use anyhow::Result;
 
 pub struct Request {}
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -18,20 +18,23 @@ impl Request {
             ));
         }
 
-        let mut d_str: String = "".to_string();
-        if !digital_channels.is_empty() {
-            d_str = format!(
+        let d_str = if !digital_channels.is_empty() {
+            format!(
                 ", digital_channels, {}",
                 Request::create_channel_str(digital_channels)?
-            );
-        }
-        let mut a_str: String = "".to_string();
-        if !analog_channels.is_empty() {
-            a_str = format!(
+            )
+        } else {
+            "".to_string()
+        };
+
+        let a_str = if !analog_channels.is_empty() {
+            format!(
                 ", analog_channels, {}",
                 Request::create_channel_str(analog_channels)?
-            );
-        }
+            )
+        } else {
+            "".to_string()
+        };
 
         Ok(format!("set_active_channels{}{}\0", d_str, a_str))
     }
@@ -41,7 +44,7 @@ impl Request {
 impl Request {
     pub fn create_channel_str(v: &[u8]) -> Result<String> {
         let s = v
-            .into_iter()
+            .iter()
             .map(|a| format!("{}, ", a.to_string()))
             .collect::<String>();
         Ok(s[..s.len() - 2].to_string())

--- a/src/response.rs
+++ b/src/response.rs
@@ -78,7 +78,7 @@ impl Response {
             .collect()
     }
 
-    pub fn parse_get_active_channels(response: &str) -> Result<(Vec<Vec<u8>>)> {
+    pub fn parse_get_active_channels(response: &str) -> Result<Vec<Vec<u8>>> {
         println!("{}", response);
         let v: Vec<&str> = response.split(',').map(|a| a.trim_start()).collect();
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -46,8 +46,8 @@ impl Response {
     pub fn parse_get_sample_rate(response: &str) -> SampleRate {
         let mut iter = response.lines();
         SampleRate {
-            AnalogSampleRate: iter.next().unwrap().parse::<u32>().unwrap(),
             DigitalSampleRate: iter.next().unwrap().parse::<u32>().unwrap(),
+            AnalogSampleRate: iter.next().unwrap().parse::<u32>().unwrap(),
         }
     }
 

--- a/src/samplerate.rs
+++ b/src/samplerate.rs
@@ -13,8 +13,8 @@ use std::str::FromStr;
 #[allow(non_snake_case)]
 #[derive(Debug, PartialEq)]
 pub struct SampleRate {
-    pub AnalogSampleRate: u32,
     pub DigitalSampleRate: u32,
+    pub AnalogSampleRate: u32,
 }
 
 impl FromStr for SampleRate {
@@ -23,8 +23,8 @@ impl FromStr for SampleRate {
         let v: Vec<&str> = response.split(',').map(|a| a.trim_start()).collect();
 
         Ok(SampleRate {
-            AnalogSampleRate: v[0].parse::<u32>().unwrap(),
-            DigitalSampleRate: v[1].parse::<u32>().unwrap(),
+            DigitalSampleRate: v[0].parse::<u32>().unwrap(),
+            AnalogSampleRate: v[1].parse::<u32>().unwrap(),
         })
     }
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1,9 +1,78 @@
 #[cfg(test)]
 mod tests {
     use saleae::client::{Client, Connection};
+    use saleae::SampleRate;
 
     #[test]
-    fn test_client() {
+    fn set_num_samples() {
+        let mut conn = Connection::faux();
+        unsafe { faux::when!(conn.run_command).then(|_| Ok(())) }
+        unsafe { faux::when!(conn.general_recieve_ack).then(|_| Ok(true)) }
+
+        let mut conn = Client::new(conn).unwrap();
+        let response = conn.set_num_samples(500).unwrap();
+        assert_eq!(true, response);
+    }
+
+    #[test]
+    fn get_num_samples() {
+        let mut conn = Connection::faux();
+        unsafe { faux::when!(conn.run_command).then(|_| Ok(())) }
+        unsafe { faux::when!(conn.general_recieve_message).then(|_| Ok("3000\nACK".to_string())) }
+
+        let mut conn = Client::new(conn).unwrap();
+        let response = conn.get_num_samples().unwrap();
+        assert_eq!(3000, response);
+    }
+
+    #[test]
+    #[should_panic]
+    fn get_num_samples_fail() {
+        let mut conn = Connection::faux();
+        unsafe { faux::when!(conn.run_command).then(|_| Ok(())) }
+        unsafe { faux::when!(conn.general_recieve_message).then(|_| Ok("3000".to_string())) }
+
+        let mut conn = Client::new(conn).unwrap();
+        let response = conn.get_num_samples().unwrap();
+        assert_eq!(3000, response);
+    }
+
+    #[test]
+    fn set_capture_seconds() {
+        let mut conn = Connection::faux();
+        unsafe { faux::when!(conn.run_command).then(|_| Ok(())) }
+        unsafe { faux::when!(conn.general_recieve_ack).then(|_| Ok(true)) }
+
+        let mut conn = Client::new(conn).unwrap();
+        let response = conn.set_capture_seconds(2.2).unwrap();
+        assert_eq!(true, response);
+    }
+
+    #[test]
+    fn set_sample_rate() {
+        let mut conn = Connection::faux();
+        unsafe { faux::when!(conn.run_command).then(|_| Ok(())) }
+        unsafe { faux::when!(conn.general_recieve_ack).then(|_| Ok(true)) }
+
+        let mut conn = Client::new(conn).unwrap();
+        let response = conn.set_sample_rate(&SampleRate {AnalogSampleRate: 6250000, DigitalSampleRate: 1562500}).unwrap();
+        assert_eq!(true, response);
+    }
+
+    #[test]
+    fn get_sample_rate() {
+        let mut conn = Connection::faux();
+        unsafe { faux::when!(conn.run_command).then(|_| Ok(())) }
+        unsafe { faux::when!(conn.general_recieve_message).then(|_| Ok("1000000\n0\n".to_string())) }
+
+        let mut conn = Client::new(conn).unwrap();
+        let response = conn.get_sample_rate().unwrap();
+        assert_eq!(response.DigitalSampleRate, 1000000);
+        assert_eq!(response.AnalogSampleRate, 0);
+    }
+
+    #[test]
+    fn get_performance() {
         let mut conn = Connection::faux();
         unsafe { faux::when!(conn.run_command).then(|_| Ok(())) }
         unsafe { faux::when!(conn.general_recieve_message).then(|_| Ok("100".to_string())) }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -55,7 +55,12 @@ mod tests {
         unsafe { faux::when!(conn.general_recieve_ack).then(|_| Ok(true)) }
 
         let mut conn = Client::new(conn).unwrap();
-        let response = conn.set_sample_rate(&SampleRate {AnalogSampleRate: 6250000, DigitalSampleRate: 1562500}).unwrap();
+        let response = conn
+            .set_sample_rate(&SampleRate {
+                AnalogSampleRate: 6250000,
+                DigitalSampleRate: 1562500,
+            })
+            .unwrap();
         assert_eq!(true, response);
     }
 
@@ -63,7 +68,9 @@ mod tests {
     fn get_sample_rate() {
         let mut conn = Connection::faux();
         unsafe { faux::when!(conn.run_command).then(|_| Ok(())) }
-        unsafe { faux::when!(conn.general_recieve_message).then(|_| Ok("1000000\n0\n".to_string())) }
+        unsafe {
+            faux::when!(conn.general_recieve_message).then(|_| Ok("1000000\n0\n".to_string()))
+        }
 
         let mut conn = Client::new(conn).unwrap();
         let response = conn.get_sample_rate().unwrap();

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1,0 +1,15 @@
+#[cfg(test)]
+mod tests {
+    use saleae::client::{Client, Connection};
+
+    #[test]
+    fn test_client() {
+        let mut conn = Connection::faux();
+        unsafe { faux::when!(conn.run_command).then(|_| Ok(())) }
+        unsafe { faux::when!(conn.general_recieve_message).then(|_| Ok("100".to_string())) }
+
+        let mut conn = Client::new(conn).unwrap();
+        let response = conn.get_performance().unwrap();
+        assert_eq!(response, 100);
+    }
+}

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1,6 +1,9 @@
 #[cfg(test)]
 mod tests {
     use saleae::client::{Client, Connection};
+    use saleae::device::DeviceID;
+    use saleae::ConnectedDevice;
+    use saleae::PerformanceOption;
     use saleae::SampleRate;
 
     #[test]
@@ -87,5 +90,190 @@ mod tests {
         let mut conn = Client::new(conn).unwrap();
         let response = conn.get_performance().unwrap();
         assert_eq!(response, 100);
+    }
+
+    #[test]
+    fn set_performance() {
+        let mut conn = Connection::faux();
+        unsafe { faux::when!(conn.run_command).then(|_| Ok(())) }
+        unsafe { faux::when!(conn.general_recieve_ack).then(|_| Ok(true)) }
+
+        let mut conn = Client::new(conn).unwrap();
+        let response = conn.set_performance(PerformanceOption::Full).unwrap();
+        assert_eq!(response, true);
+
+        let mut conn2 = Connection::faux();
+        unsafe { faux::when!(conn2.run_command).then(|_| Ok(())) }
+        unsafe { faux::when!(conn2.general_recieve_ack).then(|_| Ok(false)) }
+
+        let mut conn2 = Client::new(conn2).unwrap();
+        let response2 = conn2.set_performance(PerformanceOption::Low).unwrap();
+        assert_eq!(response2, false);
+    }
+
+    #[test]
+    fn get_connected_devices() {
+        let mut conn = Connection::faux();
+        unsafe { faux::when!(conn.run_command).then(|_| Ok(())) }
+        unsafe {
+            faux::when!(conn.general_recieve_message).then(|_| Ok("1, Logic 8, LOGIC_8_DEVICE, 0x2dc9, ACTIVE\n2, Logic Pro 8, LOGIC_PRO_8_DEVICE, 0x7243\n3, Logic Pro 16, LOGIC_PRO_16_DEVICE, 0x673f\n4, Logic 4, LOGIC_4_DEVICE, 0x6709\nACK".to_string()))
+        }
+
+        let mut conn = Client::new(conn).unwrap();
+        let response = conn.get_connected_devices().unwrap();
+        assert_eq!(
+            response[0],
+            ConnectedDevice {
+                d_type: "1".to_string(),
+                name: "Logic 8".to_string(),
+                device_id: DeviceID::LOGIC_8_DEVICE,
+                index: "0x2dc9".to_string(),
+                is_active: true
+            }
+        );
+        assert_eq!(
+            response[1],
+            ConnectedDevice {
+                d_type: "2".to_string(),
+                name: "Logic Pro 8".to_string(),
+                device_id: DeviceID::LOGIC_PRO_8_DEVICE,
+                index: "0x7243".to_string(),
+                is_active: false
+            }
+        );
+        assert_eq!(
+            response[2],
+            ConnectedDevice {
+                d_type: "3".to_string(),
+                name: "Logic Pro 16".to_string(),
+                device_id: DeviceID::LOGIC_PRO_16_DEVICE,
+                index: "0x673f".to_string(),
+                is_active: false
+            }
+        );
+        assert_eq!(
+            response[3],
+            ConnectedDevice {
+                d_type: "4".to_string(),
+                name: "Logic 4".to_string(),
+                device_id: DeviceID::LOGIC_4_DEVICE,
+                index: "0x6709".to_string(),
+                is_active: false
+            }
+        );
+    }
+
+    #[test]
+    fn select_active_device() {
+        //TODO can't test b/c of get_connected_devices not being fauxable
+        //let device = ConnectedDevice {
+        //    d_type: "4".to_string(),
+        //    name: "Logic 4".to_string(),
+        //    device_id: DeviceID::LOGIC_4_DEVICE,
+        //    index: "0x6709".to_string(),
+        //    is_active: false,
+        //};
+
+        //let mut conn = Connection::faux();
+        //unsafe { faux::when!(conn.get_connected_devices).then(|_| Ok(device)) };
+        //unsafe { faux::when!(conn.run_command).then(|_| Ok(())) }
+
+        //let mut conn = Client::new(conn).unwrap();
+        //let response = conn.select_active_device(device).unwrap();
+        //assert_eq!(response, true);
+    }
+
+    #[test]
+    fn get_active_device() {
+        let mut conn = Connection::faux();
+        unsafe { faux::when!(conn.run_command).then(|_| Ok(())) }
+        unsafe {
+            faux::when!(conn.general_recieve_message).then(|_| {
+                Ok("digital_channels, 0, 4, 5, 7, analog_channels, 0, 1, 2, 5, 8".to_string())
+            })
+        }
+
+        let mut conn = Client::new(conn).unwrap();
+        let response = conn.get_active_channels().unwrap();
+        assert_eq!(response[0], [0, 4, 5, 7]);
+        assert_eq!(response[1], [0, 1, 2, 5, 8]);
+    }
+
+    #[test]
+    fn set_active_channels() {
+        let mut conn = Connection::faux();
+        unsafe { faux::when!(conn.run_command).then(|_| Ok(())) }
+        unsafe { faux::when!(conn.general_recieve_ack).then(|_| Ok(true)) }
+
+        let mut conn = Client::new(conn).unwrap();
+        let response = conn
+            .set_active_channels(&[0, 4, 5, 7], &[0, 1, 2, 5, 8])
+            .unwrap();
+        assert_eq!(response, true);
+    }
+
+    #[test]
+    fn reset_active_channels() {
+        let mut conn = Connection::faux();
+        unsafe { faux::when!(conn.run_command).then(|_| Ok(())) }
+        unsafe { faux::when!(conn.general_recieve_ack).then(|_| Ok(true)) }
+
+        let mut conn = Client::new(conn).unwrap();
+        let response = conn.reset_active_channels().unwrap();
+        assert_eq!(response, true);
+    }
+
+    #[test]
+    fn start_capture() {
+        let mut conn = Connection::faux();
+        unsafe { faux::when!(conn.run_command).then(|_| Ok(())) }
+
+        let mut conn = Client::new(conn).unwrap();
+        let response = conn.start_capture().unwrap();
+        assert_eq!(response, true);
+    }
+
+    #[test]
+    fn start_capture_block_until_finished() {
+        let mut conn = Connection::faux();
+        unsafe { faux::when!(conn.run_command).then(|_| Ok(())) }
+        unsafe { faux::when!(conn.general_recieve_ack).then(|_| Ok(true)) }
+
+        let mut conn = Client::new(conn).unwrap();
+        let response = conn.start_capture_block_until_finished().unwrap();
+        assert_eq!(response, true);
+    }
+
+    #[test]
+    fn is_processing_complete() {
+        let mut conn = Connection::faux();
+        unsafe { faux::when!(conn.run_command).then(|_| Ok(())) }
+        unsafe { faux::when!(conn.general_recieve_message).then(|_| Ok("TRUE\nACK".to_string())) }
+
+        let mut conn = Client::new(conn).unwrap();
+        let response = conn.is_processing_complete().unwrap();
+        assert_eq!(response, true);
+    }
+
+    #[test]
+    fn stop_capture() {
+        let mut conn = Connection::faux();
+        unsafe { faux::when!(conn.run_command).then(|_| Ok(())) }
+        unsafe { faux::when!(conn.general_recieve_ack).then(|_| Ok(true)) }
+
+        let mut conn = Client::new(conn).unwrap();
+        let response = conn.stop_capture().unwrap();
+        assert_eq!(response, true);
+    }
+
+    #[test]
+    fn close_all_tabs() {
+        let mut conn = Connection::faux();
+        unsafe { faux::when!(conn.run_command).then(|_| Ok(())) }
+        unsafe { faux::when!(conn.general_recieve_ack).then(|_| Ok(true)) }
+
+        let mut conn = Client::new(conn).unwrap();
+        let response = conn.close_all_tabs().unwrap();
+        assert_eq!(response, true);
     }
 }

--- a/tests/request.rs
+++ b/tests/request.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 mod tests {
-    use anyhow::Result;
     use saleae::request::Request;
     /// Regular function tests
     #[test]

--- a/tests/response.rs
+++ b/tests/response.rs
@@ -50,9 +50,7 @@ mod tests {
             DigitalSampleRate: 6250000,
             AnalogSampleRate: 1562500,
         };
-        let result = Response::parse_get_all_sample_rates(
-            "25000000, 3125000\n6250000, 1562500\n"
-        );
+        let result = Response::parse_get_all_sample_rates("25000000, 3125000\n6250000, 1562500\n");
         assert_eq!(result[0], one);
         assert_eq!(result[1], two);
     }

--- a/tests/response.rs
+++ b/tests/response.rs
@@ -43,20 +43,18 @@ mod tests {
     #[test]
     fn test_get_all_sample_rates() {
         let one = SampleRate {
-            AnalogSampleRate: 10000000,
-            DigitalSampleRate: 625000,
+            DigitalSampleRate: 25000000,
+            AnalogSampleRate: 3125000,
         };
         let two = SampleRate {
-            AnalogSampleRate: 5000000,
-            DigitalSampleRate: 1250000,
+            DigitalSampleRate: 6250000,
+            AnalogSampleRate: 1562500,
         };
-        let expected = vec![one, two];
         let result = Response::parse_get_all_sample_rates(
-            "10000000, 625000
-                                                           5000000, 1250000",
+            "25000000, 3125000\n6250000, 1562500\n"
         );
-        assert_eq!(result[0], expected[0]);
-        assert_eq!(result[1], expected[1]);
+        assert_eq!(result[0], one);
+        assert_eq!(result[1], two);
     }
 
     #[test]

--- a/tests/samplerate.rs
+++ b/tests/samplerate.rs
@@ -8,15 +8,15 @@ mod tests {
         assert_eq!(
             SampleRate::from_str(&"5000000, 1250000").unwrap(),
             SampleRate {
-                AnalogSampleRate: 5000000,
-                DigitalSampleRate: 1250000
+                DigitalSampleRate: 5000000,
+                AnalogSampleRate: 1250000
             }
         );
         assert_eq!(
             SampleRate::from_str(&"10000000, 625000").unwrap(),
             SampleRate {
-                AnalogSampleRate: 10000000,
-                DigitalSampleRate: 625000
+                DigitalSampleRate: 10000000,
+                AnalogSampleRate: 625000
             }
         );
     }


### PR DESCRIPTION
Add the faux crate for mocking all client (public API) functions. 

This mostly relies on the Connection struct being able to be mocked in such a way that the logic program doesn't need to be running to test the code.

Per usual, mocking tests doesn't create a perfect test environment (especially when the source code of Logic isn't available).. but it should provide some more testing for the API that I have made.